### PR TITLE
New FromUnix function get rid of leap year and daylight savings config

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -114,7 +114,5 @@
     "Default": "https://cdn.example.com/images/original/monsters/{0:D3}_{1:D3}.png",
     "Shuffle": "https://cdn.example.com/images/shuffle/monsters/{0:D3}_{1:D3}.png"
   },
-  "enableDST": false,
-  "enableLeapYear": true,
   "debug": false
 }

--- a/src/Configuration/WhConfig.cs
+++ b/src/Configuration/WhConfig.cs
@@ -77,18 +77,6 @@
         public Dictionary<string, string> IconStyles { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to enable Day Light Savings time for despawn timers
-        /// </summary>
-        [JsonProperty("enableDST")]
-        public bool EnableDST { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether to enable Leap Year date adjustment for despawn timers
-        /// </summary>
-        [JsonProperty("enableLeapYear")]
-        public bool EnableLeapYear { get; set; }
-
-        /// <summary>
         /// Gets or sets whether to log incoming webhook data to a file
         /// </summary>
         [JsonProperty("debug")]

--- a/src/Extensions/IntegerExtensions.cs
+++ b/src/Extensions/IntegerExtensions.cs
@@ -4,6 +4,7 @@
 
     public static class IntegerExtensions
     {
+
         public static char NumberToAlphabet(this int num)
         {
             return Convert.ToChar(num + 64);
@@ -11,14 +12,10 @@
 
         public static DateTime FromUnix(this long unixSeconds)
         {
-            var now = DateTime.Now;
-            var timeSpan = TimeSpan.FromSeconds(unixSeconds);
-            var localDateTime = new DateTime(timeSpan.Ticks).ToLocalTime();
+            var epochTime = new DateTime(1970,1,1,0,0,0,0,DateTimeKind.Utc);
+            var localDateTime = epochTime.AddSeconds(unixSeconds).ToLocalTime();
 
-            //return localDateTime.AddHours(Convert.ToInt32(localDateTime.IsDaylightSavingTime()));
-            //return localDateTime.AddHours(1);
-            //return localDateTime;
-            return new DateTime(now.Year, localDateTime.Month, localDateTime.Day, localDateTime.Hour, localDateTime.Minute, localDateTime.Second, DateTimeKind.Local);
+            return localDateTime;
         }
     }
 }

--- a/src/Net/HttpServer.cs
+++ b/src/Net/HttpServer.cs
@@ -24,8 +24,6 @@
 
         private static readonly IEventLogger _logger = EventLogger.GetLogger("HTTP");
         private static readonly object _lock = new object();
-        private readonly bool _enableDST = false;
-        private readonly bool _enableLeapYear = false;
         private readonly Dictionary<ulong, PokemonData> _processedPokemon;
         private readonly Dictionary<string, RaidData> _processedRaids;
         private readonly Dictionary<string, GymData> _processedGyms;
@@ -121,14 +119,10 @@
         /// Instantiates a new <see cref="HttpServer"/> class.
         /// </summary>
         /// <param name="port">Listening port</param>
-        /// <param name="enableDST">Enable Day Light Savings time adjustemnt</param>
-        /// <param name="enableLeapYear">Enable leap year time adjustment</param>
-        public HttpServer(string host, ushort port, bool enableDST, bool enableLeapYear)
+        public HttpServer(string host, ushort port)
         {
             Host = host;
             Port = port;
-            _enableDST = enableDST;
-            _enableLeapYear = enableLeapYear;
             _processedPokemon = new Dictionary<ulong, PokemonData>();
             _processedRaids = new Dictionary<string, RaidData>();
             _processedGyms = new Dictionary<string, GymData>();
@@ -310,7 +304,7 @@
                     return;
                 }
 
-                pokemon.SetDespawnTime(_enableDST, _enableLeapYear);
+                pokemon.SetDespawnTime();
                 /*
                 if (_processedPokemon.ContainsKey(pokemon.EncounterId))
                 {
@@ -345,7 +339,7 @@
                     return;
                 }
 
-                raid.SetTimes(_enableDST, _enableLeapYear);
+                raid.SetTimes();
 
                 if (_processedRaids.ContainsKey(raid.GymId))
                 {
@@ -422,7 +416,7 @@
                     return;
                 }
 
-                pokestop.SetTimes(_enableDST, _enableLeapYear);
+                pokestop.SetTimes();
 
                 if (_processedPokestops.ContainsKey(pokestop.PokestopId))
                 {

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -343,43 +343,17 @@
         /// </summary>
         /// <param name="enableDST">Enable Day Light Savings time adjustment.</param>
         /// <param name="enableLeapYear">Enable leap year time adjustment.</param>
-        public void SetDespawnTime(bool enableDST, bool enableLeapYear)
+        public void SetDespawnTime()
         {
-            //TODO: DST config option
 
             DespawnTime = DisappearTime.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(DespawnTime))
-            {
-                DespawnTime = DespawnTime.AddHours(1); //DST
-            }
+
             SecondsLeft = DespawnTime.Subtract(DateTime.Now);
 
             FirstSeenTime = FirstSeen.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(FirstSeenTime))
-            {
-                FirstSeenTime = FirstSeenTime.AddHours(1); //DST
-            }
 
             LastModifiedTime = LastModified.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(LastModifiedTime))
-            {
-                LastModifiedTime = LastModifiedTime.AddHours(1);
-            }
 
-            UpdatedTime = Updated.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(UpdatedTime))
-            {
-                UpdatedTime = UpdatedTime.AddHours(1);
-            }
-
-            if (enableLeapYear)
-            {
-                DespawnTime = DespawnTime.Subtract(TimeSpan.FromHours(24));
-                FirstSeenTime = FirstSeenTime.Subtract(TimeSpan.FromHours(24));
-                LastModifiedTime = LastModifiedTime.Subtract(TimeSpan.FromHours(24));
-                UpdatedTime = UpdatedTime.Subtract(TimeSpan.FromHours(24));
-                SecondsLeft = SecondsLeft.Subtract(TimeSpan.FromHours(24));
-            }
         }
 
         public async Task<DiscordEmbed> GeneratePokemonMessage(ulong guildId, DiscordClient client, WhConfig whConfig, AlarmObject alarm, string city, string pokemonImageUrl)

--- a/src/Net/Models/PokestopData.cs
+++ b/src/Net/Models/PokestopData.cs
@@ -81,7 +81,7 @@
         /// </summary>
         public PokestopData()
         {
-            SetTimes(false, false);
+            SetTimes();
         }
 
         #region Public Methods
@@ -89,27 +89,11 @@
         /// <summary>
         /// Set expire times because .NET doesn't support Unix timestamp deserialization to <seealso cref="DateTime"/> class by default.
         /// </summary>
-        /// <param name="enableDST">Enable Day Light Savings time adjustment.</param>
-        /// <param name="enableLeapYear">Enable leap year time adjustment.</param>
-        public void SetTimes(bool enableDST, bool enableLeapYear)
+        public void SetTimes()
         {
             LureExpireTime = LureExpire.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(LureExpireTime))
-            {
-                LureExpireTime = LureExpireTime.AddHours(1); //DST
-            }
 
             InvasionExpireTime = IncidentExpire.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(InvasionExpireTime))
-            {
-                InvasionExpireTime = InvasionExpireTime.AddHours(1); //DST
-            }
-
-            if (enableLeapYear)
-            {
-                LureExpireTime = LureExpireTime.Subtract(TimeSpan.FromDays(1));
-                InvasionExpireTime = InvasionExpireTime.Subtract(TimeSpan.FromDays(1));
-            }
         }
 
         public static string InvasionTypeToString(InvasionGruntType gruntType)

--- a/src/Net/Models/RaidData.cs
+++ b/src/Net/Models/RaidData.cs
@@ -114,33 +114,14 @@
         /// </summary>
         public RaidData()
         {
-            SetTimes(false, false);
+            SetTimes();
         }
 
-        /// <summary>
-        /// Set start and end times because .NET doesn't support Unix timestamp deserialization to <seealso cref="DateTime"/> class by default.
-        /// </summary>
-        /// <param name="enableDST">Enable Day Light Savings time adjustment.</param>
-        /// <param name="enableLeapYear">Enable leap year time adjustment.</param>
-        public void SetTimes(bool enableDST, bool enableLeapYear)
+        public void SetTimes()
         {
             StartTime = Start.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(StartTime))
-            {
-                StartTime = StartTime.AddHours(1); //DST
-            }
 
             EndTime = End.FromUnix();
-            if (enableDST)//TimeZoneInfo.Local.IsDaylightSavingTime(EndTime))
-            {
-                EndTime = EndTime.AddHours(1); //DST
-            }
-
-            if (enableLeapYear)
-            {
-                StartTime = StartTime.Subtract(TimeSpan.FromDays(1));
-                EndTime = EndTime.Subtract(TimeSpan.FromDays(1));
-            }
         }
 
         public DiscordEmbed GenerateRaidMessage(ulong guildId, DiscordClient client, WhConfig whConfig, AlarmObject alarm, string city, string raidImageUrl)

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -194,7 +194,7 @@
             }
             _config = config;
 
-            _http = new HttpServer(_config.ListeningHost, _config.WebhookPort, _config.EnableDST, _config.EnableLeapYear);
+            _http = new HttpServer(_config.ListeningHost, _config.WebhookPort);
             _http.PokemonReceived += Http_PokemonReceived;
             _http.RaidReceived += Http_RaidReceived;
             _http.QuestReceived += Http_QuestReceived;


### PR DESCRIPTION
Updated FromUnix to be able to convert unix times from the webhook data to current local time without using daylight savings or leap year configs. I tested this for raids, invasions, and pokemon. The times matched up with times in the database.