### PR TITLE
Fix json property for weather id

### DIFF
--- a/src/Net/Models/WeatherData.cs
+++ b/src/Net/Models/WeatherData.cs
@@ -35,7 +35,7 @@
 
         #region Properties
 
-        [JsonProperty("id")]
+        [JsonProperty("s2_cell_id")]
         public long Id { get; set; }
 
         [JsonProperty("latitude")]


### PR DESCRIPTION
It seems RDM is sending weather id as s2_cell_id in JSON

https://github.com/RealDeviceMap/RealDeviceMap/blob/d275658c3d5d532d94d33a704c89848d6fae9ec3/Sources/RealDeviceMap/Modell/Weather.swift#L63

My cell ID in discord alert was always 0