### PR TITLE
OSM Nominatim Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ bitsadmin /transfer dotnet-install-job /download /priority FOREGROUND https://ra
 8.) Build executable `dotnet build ../../..` (if dotnet is in your path) otherwise `~/.dotnet/dotnet build ../../..`  
 9.) Start WhMgr `dotnet WhMgr.dll` (if dotnet is in your path) otherwise `~/.dotnet/dotnet WhMgr.dll` (If Windows, run as Administrator)  
 10.) Optional User Interface for members to create subscriptions from a website instead of using Discord commands. (Still WIP but mostly done) [WhMgr UI](https://github.com/versx/WhMgr-UI)  
+11.) Optional reverse location lookup with OpenStreetMaps Nominatim instead of Google Maps, install instructions [here](https://nominatim.org/release-docs/develop/admin/Installation/)  
 
 ## Updating  
 1.) Pull latest changes in root folder  

--- a/config.example.json
+++ b/config.example.json
@@ -141,6 +141,7 @@
     "minIV": 100
   },
   "gmapsKey": "",
+  "nominatim": "https://nominatim.openstreetmap.org",
   "despawnTimeMinimumMinutes": 5,
   "reloadSubscriptionChangesMinutes": 1,
   "debug": false,

--- a/src/Commands/Nests.cs
+++ b/src/Commands/Nests.cs
@@ -145,7 +145,15 @@
             var geofences = _dep.Whm.Geofences.Values.ToList();
             var geofence = GeofenceService.GetGeofence(geofences, new Location(nest.Latitude, nest.Longitude));
             var city = geofence?.Name ?? "Unknown";
-            var googleAddress = Utils.GetGoogleAddress(city, nest.Latitude, nest.Longitude, _dep.WhConfig.GoogleMapsKey);
+            Location address;
+            if (!string.IsNullOrEmpty(_dep.WhConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, nest.Latitude, nest.Longitude, _dep.WhConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, nest.Latitude, nest.Longitude, _dep.WhConfig.NominatimEndpoint);
+            }
 
             var dict = new Dictionary<string, string>
             {
@@ -177,7 +185,7 @@
                 { "wazemaps_url", wazeMapsLink },
                 { "scanmaps_url", scannerMapsLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 // Discord Guild properties
                 { "guild_name", guild?.Name },

--- a/src/Configuration/WhConfig.cs
+++ b/src/Configuration/WhConfig.cs
@@ -93,6 +93,12 @@
         public string GoogleMapsKey { get; set; }
 
         /// <summary>
+        /// Gets or sets the OpenStreetMaps Nominatim endpoint to use for reverse location lookup
+        /// </summary>
+        [JsonProperty("nominatim")]
+        public string NominatimEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets the minimum despawn time in minutes a Pokemon must have in order to send the alarm
         /// </summary>
         [JsonProperty("despawnTimeMinimumMinutes")]

--- a/src/Net/Models/GymDetailsData.cs
+++ b/src/Net/Models/GymDetailsData.cs
@@ -144,7 +144,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Net/Models/GymDetailsData.cs
+++ b/src/Net/Models/GymDetailsData.cs
@@ -144,7 +144,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
 
             const string defaultMissingValue = "?";
@@ -185,7 +193,7 @@
                 { "wazemaps_url", wazeMapsLocationLink },
                 { "scanmaps_url", scannerMapsLocationLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 // Discord Guild properties
                 { "guild_name", guild?.Name },

--- a/src/Net/Models/GymDetailsData.cs
+++ b/src/Net/Models/GymDetailsData.cs
@@ -149,7 +149,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -483,7 +483,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -379,7 +379,7 @@
             DespawnTime = DisappearTime.FromUnix()
                 .ConvertTimeFromCoordinates(Latitude, Longitude);
 
-            SecondsLeft = DespawnTime.Subtract(DateTime.Now.ConvertTimeFromCoordinates(Latitude, Longitude));
+            SecondsLeft = DespawnTime.Subtract(DateTime.UtcNow.ConvertTimeFromCoordinates(Latitude, Longitude));
 
             FirstSeenTime = FirstSeen
                 .FromUnix()

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -478,7 +478,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
             var pokestop = Pokestop.Pokestops.ContainsKey(PokestopId) ? Pokestop.Pokestops[PokestopId] : null;
 
@@ -579,7 +587,7 @@
                 { "wazemaps_url", wazeMapsLocationLink },
                 { "scanmaps_url", scannerMapsLocationLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 // Pokestop properties
                 { "near_pokestop", Convert.ToString(pokestop != null) },

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -478,7 +478,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Net/Models/PokestopData.cs
+++ b/src/Net/Models/PokestopData.cs
@@ -155,7 +155,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Net/Models/PokestopData.cs
+++ b/src/Net/Models/PokestopData.cs
@@ -155,7 +155,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
             var invasion = MasterFile.Instance.GruntTypes.ContainsKey(GruntType) ? MasterFile.Instance.GruntTypes[GruntType] : null;
             var leaderString = Translator.Instance.Translate("grunt_" + Convert.ToInt32(GruntType));
@@ -204,7 +212,7 @@
                 { "lure_img_url", lureImageUrl },
                 { "invasion_img_url", invasionImageUrl },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 // Discord Guild properties
                 { "guild_name", guild?.Name },

--- a/src/Net/Models/PokestopData.cs
+++ b/src/Net/Models/PokestopData.cs
@@ -160,7 +160,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/QuestData.cs
+++ b/src/Net/Models/QuestData.cs
@@ -119,7 +119,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
 
             const string defaultMissingValue = "?";
@@ -148,7 +156,7 @@
                 { "wazemaps_url", wazeMapsLocationLink },
                 { "scanmaps_url", scannerMapsLocationLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 //Pokestop properties
                 { "pokestop_id", PokestopId ?? defaultMissingValue },

--- a/src/Net/Models/QuestData.cs
+++ b/src/Net/Models/QuestData.cs
@@ -119,7 +119,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Net/Models/QuestData.cs
+++ b/src/Net/Models/QuestData.cs
@@ -124,7 +124,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/RaidData.cs
+++ b/src/Net/Models/RaidData.cs
@@ -211,7 +211,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
 
             const string defaultMissingValue = "?";
@@ -275,7 +283,7 @@
                 { "wazemaps_url", wazeMapsLocationLink },
                 { "scanmaps_url", scannerMapsLocationLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 //Gym properties
                 { "gym_id", GymId },

--- a/src/Net/Models/RaidData.cs
+++ b/src/Net/Models/RaidData.cs
@@ -216,7 +216,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/RaidData.cs
+++ b/src/Net/Models/RaidData.cs
@@ -211,7 +211,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Net/Models/WeatherData.cs
+++ b/src/Net/Models/WeatherData.cs
@@ -134,6 +134,10 @@
             return new DiscordEmbedNotification(username, iconUrl, description, new List<DiscordEmbed> { eb.Build() });
         }
 
+        #endregion
+
+        #region Private Methods
+
         private IReadOnlyDictionary<string, string> GetProperties(DiscordGuild guild, WhConfig whConfig, string city, string weatherImageUrl)
         {
             var weather = Translator.Instance.GetWeather(GameplayCondition);
@@ -150,7 +154,15 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            var googleAddress = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            Geofence.Location address;
+            if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
+            {
+                address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
+            }
+            else
+            {
+                address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
+            }
             //var staticMapLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? staticMapLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, staticMapLink);
 
             const string defaultMissingValue = "?";
@@ -188,7 +200,7 @@
                 { "wazemaps_url", wazeMapsLocationLink },
                 { "scanmaps_url", scannerMapsLocationLink },
 
-                { "address", googleAddress?.Address },
+                { "address", address?.Address },
 
                 // Discord Guild properties
                 { "guild_name", guild?.Name },

--- a/src/Net/Models/WeatherData.cs
+++ b/src/Net/Models/WeatherData.cs
@@ -159,7 +159,7 @@
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);
             }
-            else
+            else if (!string.IsNullOrEmpty(whConfig.NominatimEndpoint))
             {
                 address = Utils.GetNominatimAddress(city, Latitude, Longitude, whConfig.NominatimEndpoint);
             }

--- a/src/Net/Models/WeatherData.cs
+++ b/src/Net/Models/WeatherData.cs
@@ -154,7 +154,7 @@
             var appleMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? appleMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, appleMapsLink);
             var wazeMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? wazeMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, wazeMapsLink);
             var scannerMapsLocationLink = string.IsNullOrEmpty(whConfig.ShortUrlApiUrl) ? scannerMapsLink : NetUtil.CreateShortUrl(whConfig.ShortUrlApiUrl, scannerMapsLink);
-            Geofence.Location address;
+            Geofence.Location address = null;
             if (!string.IsNullOrEmpty(whConfig.GoogleMapsKey))
             {
                 address = Utils.GetGoogleAddress(city, Latitude, Longitude, whConfig.GoogleMapsKey);

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -110,5 +110,27 @@
             }
             return null;
         }
+
+        public static Location GetNominatimAddress(string city, double lat, double lng, string endpoint)
+        {
+            var unknown = "Unknown";
+            var url = $"{endpoint}/reverse?format=jsonv2&lat={lat}&lon={lng}";
+            try
+            {
+                using (var wc = new WebClient())
+                {
+                    wc.Proxy = null;
+                    wc.Headers.Add("User-Agent", Strings.BotName);
+                    var json = wc.DownloadString(url);
+                    dynamic obj = JsonConvert.DeserializeObject(json);
+                    return new Location(Convert.ToString(obj.display_name), city ?? unknown, Convert.ToDouble(obj.lat), Convert.ToDouble(obj.lon));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex);
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Uses specified OpenStreetMaps Nominatim endpoint for reverse location lookup if `gmapsKey` property in `config.json` is null/empty.

Default endpoint is provided as an example, you should install your own Nominatim server.  