### PR TITLE
Fix event Pokemon IV operator check

### DIFF
--- a/src/Data/Subscriptions/SubscriptionProcessor.cs
+++ b/src/Data/Subscriptions/SubscriptionProcessor.cs
@@ -315,14 +315,15 @@
                     }
 
                     matchesGreat = pkmn.GreatLeague != null && (pkmn.GreatLeague?.Exists(x => subscribedPokemon.League == PvPLeague.Great &&
-                                                                     (x.CP ?? 0) >= 1400 && (x.CP ?? 0) <= 1500 &&
+                                                                     (x.CP ?? 0) >= Strings.MinimumGreatLeagueCP && (x.CP ?? 0) <= Strings.MaximumGreatLeagueCP &&
                                                                      (x.Rank ?? 4096) <= subscribedPokemon.MinimumRank &&
                                                                      (x.Percentage ?? 0) * 100 >= subscribedPokemon.MinimumPercent) ?? false);
                     matchesUltra = pkmn.UltraLeague != null && (pkmn.GreatLeague?.Exists(x => subscribedPokemon.League == PvPLeague.Ultra &&
-                                                                     (x.CP ?? 0) >= 2400 && (x.CP ?? 0) <= 2500 &&
+                                                                     (x.CP ?? 0) >= Strings.MinimumUltraLeagueCP && (x.CP ?? 0) <= Strings.MaximumUltraLeagueCP &&
                                                                      (x.Rank ?? 4096) <= subscribedPokemon.MinimumRank &&
                                                                      (x.Percentage ?? 0) * 100 >= subscribedPokemon.MinimumPercent) ?? false);
 
+                    // Check if Pokemon IV stats match any relevant great or ultra league ranks, if not skip.
                     if (!matchesGreat && !matchesUltra)
                         continue;
 

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -234,13 +234,13 @@
             // Check if Pokemon is in event Pokemon list
             if (_config.EventPokemonIds.Contains(pkmn.Id) && _config.EventPokemonIds.Count > 0)
             {
-                //Skip Pokemon if no IV stats.
+                // Skip Pokemon if no IV stats.
                 if (pkmn.IsMissingStats)
                     return;
 
                 var iv = PokemonData.GetIV(pkmn.Attack, pkmn.Defense, pkmn.Stamina);
-                //Skip Pokemon if IV is less than 90%, not 0%, and does not match any PvP league stats.
-                if ((iv < 90 && iv != 0) || !pkmn.MatchesGreatLeague || !pkmn.MatchesUltraLeague)
+                // Skip Pokemon if IV is greater than 0%, less than 90%, and does not match any PvP league stats.
+                if (iv > 0 && iv < 90 && !pkmn.MatchesGreatLeague && !pkmn.MatchesUltraLeague)
                     return;
             }
 
@@ -460,7 +460,7 @@
                     if (alarm.Filters.Pokemon.IsPvpGreatLeague &&
                         !(pkmn.MatchesGreatLeague && pkmn.GreatLeague.Exists(x =>
                             Filters.MatchesPvPRank(x.Rank ?? 4096, alarm.Filters.Pokemon.MinimumRank, alarm.Filters.Pokemon.MaximumRank)
-                            && x.CP >= 1400 && x.CP <= 1500)))
+                            && x.CP >= Strings.MinimumGreatLeagueCP && x.CP <= Strings.MaximumGreatLeagueCP)))
                     {
                         continue;
                     }
@@ -468,7 +468,7 @@
                     if (alarm.Filters.Pokemon.IsPvpUltraLeague &&
                         !(pkmn.MatchesUltraLeague && pkmn.UltraLeague.Exists(x =>
                             Filters.MatchesPvPRank(x.Rank ?? 4096, alarm.Filters.Pokemon.MinimumRank, alarm.Filters.Pokemon.MaximumRank)
-                            && x.CP >= 2400 && x.CP <= 2500)))
+                            && x.CP >= Strings.MinimumUltraLeagueCP && x.CP <= Strings.MaximumUltraLeagueCP)))
                     {
                         continue;
                     }


### PR DESCRIPTION
- Fix event Pokemon IV check if IV is greater than 0%, lower than 90% and does not have relevant pvp stats (Thanks to petap0w for pointing it out)
- Use min/max PvP CP constants