### PR TITLE
Customizable Minimum IV for Event Pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ bitsadmin /transfer dotnet-install-job /download /priority FOREGROUND https://ra
         456,
         320
     ],
+	// Minimum IV value for an event Pokemon to have to meet in order to post via Discord channel alarm or direct message subscription.
+    "eventMinimumIV": "90",
     // Image URL config
     "urls": {
         // Static tile map images template.

--- a/config.example.json
+++ b/config.example.json
@@ -92,6 +92,7 @@
     456,
     320
   ],
+  "eventMinimumIV": "90",
   "urls": {
     "staticMap": "http://tiles.example.com:8080/static/klokantech-basic/{0}/{1}/{2}/300/175/1/png",
     "scannerMap": "http://map.example.com/@/{0}/{1}/15"

--- a/src/Configuration/WhConfig.cs
+++ b/src/Configuration/WhConfig.cs
@@ -69,6 +69,13 @@
         public List<int> EventPokemonIds { get; set; }
 
         /// <summary>
+        /// Gets or sets the minimum IV value for an event Pokemon to be to process
+        /// for channel alarms or direct message subscriptions
+        /// </summary>
+        [JsonProperty("eventMinimumIV")]
+        public int EventMinimumIV { get; set; }
+
+        /// <summary>
         /// Gets or sets the icon styles
         /// </summary>
         [JsonProperty("iconStyles")]
@@ -141,6 +148,7 @@
             Database = new ConnectionStringsConfig();
             Urls = new UrlConfig();
             EventPokemonIds = new List<int>();
+            EventMinimumIV = 90;
             IconStyles = new Dictionary<string, string>();
             StaticMaps = new StaticMaps();
             Twilio = new TwilioConfig();

--- a/src/Net/HttpServer.cs
+++ b/src/Net/HttpServer.cs
@@ -219,10 +219,12 @@
                 if (context.Request?.InputStream == null)
                     continue;
 
+                // Read from the POST data input stream of the request
                 using (var sr = new StreamReader(context.Request.InputStream))
                 {
                     try
                     {
+                        // Read to the end of the stream as a string
                         var data = sr.ReadToEnd();
                         ParseData(data);
                     }
@@ -237,12 +239,15 @@
 
                 try
                 {
+                    // Convert the default response message to UTF8 encoded bytes
                     var buffer = Encoding.UTF8.GetBytes(Strings.DefaultResponseMessage);
                     response.ContentLength64 = buffer.Length;
                     if (response?.OutputStream != null)
                     {
+                        // Write the response buffer to the output stream
                         response.OutputStream.Write(buffer, 0, buffer.Length);
                     }
+                    // Close the response
                     context.Response.Close();
                 }
                 catch (Exception ex)

--- a/src/Net/Webhooks/WebhookController.cs
+++ b/src/Net/Webhooks/WebhookController.cs
@@ -253,7 +253,7 @@
 
                 var iv = PokemonData.GetIV(pkmn.Attack, pkmn.Defense, pkmn.Stamina);
                 // Skip Pokemon if IV is greater than 0%, less than 90%, and does not match any PvP league stats.
-                if (iv > 0 && iv < 90 && !pkmn.MatchesGreatLeague && !pkmn.MatchesUltraLeague)
+                if (iv > 0 && iv < _config.EventMinimumIV && !pkmn.MatchesGreatLeague && !pkmn.MatchesUltraLeague)
                     return;
             }
 


### PR DESCRIPTION
Adds the option to specify a minimum IV value for an event Pokemon to post to Discord channel alarms or direct message subscriptions.