### PR TITLE
Change Pokestop.CellId to ulong

### DIFF
--- a/src/Data/Models/Pokestop.cs
+++ b/src/Data/Models/Pokestop.cs
@@ -99,7 +99,7 @@
         public ItemId QuestItemId { get; set; }
 
         [Alias("cell_id")]
-        public long CellId { get; set; }
+        public ulong CellId { get; set; }
 
         #endregion
 


### PR DESCRIPTION
Fixes #88 where a `System.OverflowException` would occur in the ORM when loading a Pokestop with a `cell_id` greater than `9223372036854775807`