### PR TITLE
Batch Discord member calls that are made simutaneously before the cache exists

### DIFF
--- a/src/Extensions/DiscordExtensions.cs
+++ b/src/Extensions/DiscordExtensions.cs
@@ -103,39 +103,39 @@
 
         #endregion
 
-		private static readonly Dictionary<(ulong, ulong), Task<DiscordMember>> MemberTasks = new Dictionary<(ulong, ulong), Task<DiscordMember>>();
+        private static readonly Dictionary<(ulong, ulong), Task<DiscordMember>> MemberTasks = new Dictionary<(ulong, ulong), Task<DiscordMember>>();
 
-		public static async Task<DiscordMember> GetMemberById( this DiscordClient client, ulong guildId, ulong id )
-		{
-			Task<DiscordMember> taskToAwait;
-			var                 added = false;
+        public static async Task<DiscordMember> GetMemberById(this DiscordClient client, ulong guildId, ulong id)
+        {
+            Task<DiscordMember> taskToAwait;
+            var added = false;
 
-			lock ( MemberTasks )
-			{
-				if ( MemberTasks.TryGetValue( ( guildId, id ), out var existingTask ) )
-				{
-					taskToAwait = existingTask;
-				}
-				else
-				{
-					taskToAwait = DoGetMemberById( client, guildId, id );
-					MemberTasks.Add( ( guildId, id ), taskToAwait );
-					added = true;
-				}
-			}
+            lock (MemberTasks)
+            {
+                if (MemberTasks.TryGetValue((guildId, id), out var existingTask))
+                {
+                    taskToAwait = existingTask;
+                }
+                else
+                {
+                    taskToAwait = DoGetMemberById(client, guildId, id);
+                    MemberTasks.Add((guildId, id), taskToAwait);
+                    added = true;
+                }
+            }
 
-			var result = await taskToAwait;
+            var result = await taskToAwait;
 
-			if ( added )
-			{
-				lock ( MemberTasks )
-				{
-					MemberTasks.Remove( ( guildId, id ) );
-				}
-			}
+            if (added)
+            {
+                lock (MemberTasks)
+                {
+                    MemberTasks.Remove((guildId, id));
+                }
+            }
 
-			return result;
-		}
+            return result;
+        }
 
         private static async Task<DiscordMember> DoGetMemberById(DiscordClient client, ulong guildId, ulong id)
 		{

--- a/src/Extensions/DiscordExtensions.cs
+++ b/src/Extensions/DiscordExtensions.cs
@@ -103,8 +103,42 @@
 
         #endregion
 
-        public static async Task<DiscordMember> GetMemberById(this DiscordClient client, ulong guildId, ulong id)
-        {
+		private static readonly Dictionary<(ulong, ulong), Task<DiscordMember>> MemberTasks = new Dictionary<(ulong, ulong), Task<DiscordMember>>();
+
+		public static async Task<DiscordMember> GetMemberById( this DiscordClient client, ulong guildId, ulong id )
+		{
+			Task<DiscordMember> taskToAwait;
+			var                 added = false;
+
+			lock ( MemberTasks )
+			{
+				if ( MemberTasks.TryGetValue( ( guildId, id ), out var existingTask ) )
+				{
+					taskToAwait = existingTask;
+				}
+				else
+				{
+					taskToAwait = DoGetMemberById( client, guildId, id );
+					MemberTasks.Add( ( guildId, id ), taskToAwait );
+					added = true;
+				}
+			}
+
+			var result = await taskToAwait;
+
+			if ( added )
+			{
+				lock ( MemberTasks )
+				{
+					MemberTasks.Remove( ( guildId, id ) );
+				}
+			}
+
+			return result;
+		}
+
+        private static async Task<DiscordMember> DoGetMemberById(DiscordClient client, ulong guildId, ulong id)
+		{
             if (!client.Guilds.ContainsKey(guildId))
                 return null;
 


### PR DESCRIPTION
Addresses #93 

The rate limit problem is solved by initially caching the `Task<DiscordMember>` representing the initial call to the Discord API for a particular `guildId`/`memberId` combo, and then returning that same task for any subsequent calls with the same combo until the Task finishes, instead of starting multiple parallel Tasks for the same call. Once the initial call finishes, the user is in the cache already and future calls will return almost instantly.

I've been using the changes from this in my own instance for about a day and a half now; seems to be working just fine.