### PR TITLE
Bugfix: Ensure that encounterId is not null 

### DIFF
--- a/src/Net/HttpServer.cs
+++ b/src/Net/HttpServer.cs
@@ -637,13 +637,16 @@
             for (var i = 0; i < keys.Count; i++)
             {
                 var encounterId = keys[i];
-                var scannedPokemon = _processedPokemon[encounterId];
-
-                if (scannedPokemon.IsExpired)
+                if (encounterId != null)
                 {
-                    // Spawn expired, remove from cache
-                    _logger.Debug($"Pokemon spawn {encounterId} expired, removing from cache...");
-                    _processedPokemon.Remove(encounterId);
+                    var scannedPokemon = _processedPokemon[encounterId];
+
+                    if (scannedPokemon.IsExpired)
+                    {
+                        // Spawn expired, remove from cache
+                        _logger.Debug($"Pokemon spawn {encounterId} expired, removing from cache...");
+                        _processedPokemon.Remove(encounterId);
+                    }
                 }
             }
         }


### PR DESCRIPTION
OnClearCache was throwing Null Exceptions, added a check to ensure that encounterId was not null before looking for a processedPokemon.  