### PR TITLE
Fix logLevel property in config file not doing anything

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -69,6 +69,8 @@
             }
             whConfig.FileName = configFilePath;
 
+            LogLevel = whConfig.LogLevel;
+
             // Start bot
             var bot = new Bot(whConfig);
             await bot.Start();


### PR DESCRIPTION
The `logLevel` property in the config file isn't used anywhere in the code, and `Program.LogLevel` is never set anywhere in the code. This PR simply links the two together! I noticed my log files are getting massive because of all the expired Pokemon logging going on, so I wanted to change the level to `Info` instead of `Debug`.

I also included a second fix for my last PR regarding webhook thread safety; somehow the changes I made to the `OnClearCache` method in `HttpServer` got lost; there should be a lock around access to `_processedPokemon` there too. I added one, and moved the cache logging out of the lock so that it doesn't slow things down too much for the processing thread.