### PR TITLE
Allow half levels to show in PVP notification

### DIFF
--- a/src/Net/Models/PVPRank.cs
+++ b/src/Net/Models/PVPRank.cs
@@ -20,7 +20,7 @@
         public int FormId { get; set; }
 
         [JsonProperty("level")]
-        public ushort? Level { get; set; }
+        public double? Level { get; set; }
 
         [JsonProperty("cp")]
         public int? CP { get; set; }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36616001/103059015-79aa0400-4569-11eb-98a1-b911d5660808.png)
Half levels now show in the PVP stats