### PR TITLE
Remove ServiceStack.OrmLite 10 table limit

### DIFF
--- a/src/App.config
+++ b/src/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="servicestack:license" value="17730-e1JlZjoxNzczMCxOYW1lOlhZWiBTb2Z0d2FyZSBTb2x1dGlvbnMsVHlwZTpJbmRpZSxNZXRhOjAsSGFzaDpPY2RkK21NT0VZSlJpcjZ0NXNwUGhuTGlxdDFyYmtjMkQrUE5XTE5jSnluT1BSbjlqc0VrSGUwb0tKZmszVEsxTjhCSmFmS3FjNXB0YTNhM1QreUJjSEZ5S1I2Smtmem54U09QK2d5WlhBdkpUZXNNbUkvOTErb1YzUm5PaWZqL3NUODE3R2RzWkFTVDByY25LN1JZbldKMmRoUXNoNTVWSmY1U1NMTzRjelU9LEV4cGlyeToyMDIyLTAzLTE0fQ==" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
Removes the 10 table limit from the ServiceStack.OrmLite library by providing a license key.