### PR TITLE
Fix iv_list check for Pokemon subscriptions

### DIFF
--- a/src/Data/Subscriptions/SubscriptionProcessor.cs
+++ b/src/Data/Subscriptions/SubscriptionProcessor.cs
@@ -174,7 +174,7 @@ namespace WhMgr.Data.Subscriptions
                     //var matchesCP = _whm.Filters.MatchesCpFilter(pkmn.CP, subscribedPokemon.MinimumCP);
                     matchesLvl = Filters.MatchesLvl(pkmn.Level, (uint)subscribedPokemon.MinimumLevel, (uint)subscribedPokemon.MaximumLevel);
                     matchesGender = Filters.MatchesGender(pkmn.Gender, subscribedPokemon.Gender);
-                    matchesIVList = subscribedPokemon.IVList?.Contains($"{pkmn.Attack}/{pkmn.Defense}/{pkmn.Stamina}") ?? false;
+                    matchesIVList = subscribedPokemon.IVList?.Exists(x => x.Contains($"{pkmn.Attack}/{pkmn.Defense}/{pkmn.Stamina}")) ?? false;
 
                     if (!(
                         (!subscribedPokemon.HasStats && matchesIV && matchesLvl && matchesGender) ||

--- a/src/Net/Models/PokemonData.cs
+++ b/src/Net/Models/PokemonData.cs
@@ -300,13 +300,27 @@
             JsonIgnore,
             Ignore
         ]
-        public bool MatchesGreatLeague => GreatLeague?.Exists(x => x.Rank <= MaximumRankPVP && x.CP >= Strings.MinimumGreatLeagueCP && x.CP <= Strings.MaximumGreatLeagueCP) ?? false;
+        public bool MatchesGreatLeague => GreatLeague?.Exists(x =>
+            // Check if stat rank is less than or equal to the max great league rank stat desired
+            x.Rank <= MaximumRankPVP &&
+            // Check if stat CP is greater than or equal to min great league CP
+            x.CP >= Strings.MinimumGreatLeagueCP &&
+            // Check if stat CP is less than or equal to max great league CP
+            x.CP <= Strings.MaximumGreatLeagueCP
+        ) ?? false;
 
         [
             JsonIgnore,
             Ignore
         ]
-        public bool MatchesUltraLeague => UltraLeague?.Exists(x => x.Rank <= MaximumRankPVP && x.CP >= Strings.MinimumUltraLeagueCP && x.CP <= Strings.MaximumUltraLeagueCP) ?? false;
+        public bool MatchesUltraLeague => UltraLeague?.Exists(x =>
+            // Check if stat rank is less than or equal to the max ultra league rank stat desired
+            x.Rank <= MaximumRankPVP &&
+            // Check if stat CP is greater than or equal to min ultra league CP
+            x.CP >= Strings.MinimumUltraLeagueCP &&
+            // Check if stat CP is less than or equal to max ultra league CP
+            x.CP <= Strings.MaximumUltraLeagueCP
+        ) ?? false;
 
 
         [


### PR DESCRIPTION
Check if each individual value contains instead of checking exact values, incase of `iv_list` values having `\r` with one of the IVs which would cause a failed check. i.e. `0/15\r/15`
Fixes: https://github.com/versx/WhMgr-UI/issues/40